### PR TITLE
fix bug

### DIFF
--- a/source/worksheet/worksheet.cpp
+++ b/source/worksheet/worksheet.cpp
@@ -315,12 +315,14 @@ void worksheet::freeze_panes(const cell_reference &ref)
         primary_view.add_selection(selection(pane_corner::bottom_left, ref));
         primary_view.pane().active_pane = pane_corner::bottom_left;
         primary_view.pane().y_split = ref.row() - 1;
+        primary_view.pane().x_split = ref.column_index() - 1;
     }
     else if (ref.row() == 1) // no row is frozen
     {
         primary_view.add_selection(selection(pane_corner::top_right, ref));
         primary_view.pane().active_pane = pane_corner::top_right;
         primary_view.pane().x_split = ref.column_index() - 1;
+        primary_view.pane().y_split = ref.row() - 1;
     }
     else // column and row is frozen
     {


### PR DESCRIPTION
when use A2 or B1, it will always free both column and row.
fix: A2 only freeze row; B1 only free comumn.